### PR TITLE
Update CI to align with other team projects

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,3 @@
+# https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#configuration
+
+enabled: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "docker"
+    target-branch: main
+    directories:
+    # CUDA image
+    - "/deployments/container"
+    # Golang version
+    - "/deployments/devel"
+    schedule:
+      interval: "daily"
+    labels:
+    - dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+# Copyright 2025 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+      - main
+      - release-*
+
+jobs:
+  code-scanning:
+    uses: ./.github/workflows/code_scanning.yaml
+
+  variables:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Generate Commit Short SHA
+        id: version
+        run: echo "version=$(echo $GITHUB_SHA | cut -c1-8)" >> "$GITHUB_OUTPUT"
+
+  golang:
+    uses: ./.github/workflows/golang.yaml

--- a/.github/workflows/code_scanning.yaml
+++ b/.github/workflows/code_scanning.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 NVIDIA CORPORATION
+# Copyright 2025 NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,42 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Golang
+name: "CodeQL"
 
 on:
+  workflow_call: {}
   pull_request:
-    branches:
-      - main
-      - release-*
-  push:
+    types:
+      - opened
+      - synchronize
     branches:
       - main
       - release-*
 
 jobs:
-  lint:
+  analyze:
+    name: Analyze Go code with CodeQL
     runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      packages: read
     steps:
-    - uses: actions/checkout@v4
-      name: Checkout code
-    - name: Install Go
-      uses: actions/setup-go@v5
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
       with:
-        go-version-file: 'go.mod'
-    - name: Lint
-      uses: golangci/golangci-lint-action@v6
+        languages: go
+        build-mode: manual
+
+    - shell: bash
+      run: |
+        make build
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
       with:
-        version: latest
-        args: -v --timeout 5m
-        skip-cache: true
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      name: Checkout code
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-    - name: Build
-      run: make build
+        category: "/language:go"

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -1,0 +1,74 @@
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Golang
+
+on:
+  workflow_call: {}
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+      - release-*
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout code
+
+    - name: Get Golang version
+      id: vars
+      run: |
+        GOLANG_VERSION=$(./hack/golang-version.sh)
+        echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION := }" >> $GITHUB_ENV
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GOLANG_VERSION }}
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
+        args: -v --timeout 5m
+        skip-cache: true
+
+    - name: Check golang modules
+      run: | 
+        make check-vendor
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get Golang version
+        id: vars
+        run: |
+          GOLANG_VERSION=$(./hack/golang-version.sh)
+          echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
+      - run: make build

--- a/deployments/devel/Dockerfile
+++ b/deployments/devel/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile is also used to define the golang version used in this project
+# This allows dependabot to manage this version in addition to other images.
+FROM golang:1.24.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/NVIDIA/kubectl-nv
 
-go 1.22.0
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	github.com/NVIDIA/gpu-operator v1.11.1

--- a/hack/golang-version.sh
+++ b/hack/golang-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2025 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../hack && pwd )"
+
+DOCKERFILE_ROOT=${SCRIPTS_DIR}/../deployments/devel
+
+GOLANG_VERSION=$(grep -E "^FROM golang:.*$" ${DOCKERFILE_ROOT}/Dockerfile | grep -oE "[0-9\.]+")
+
+echo $GOLANG_VERSION


### PR DESCRIPTION
This pull request includes several updates to GitHub workflows, configuration files, and the addition of new scripts. The most important changes include enabling the copy-pr-bot, updating the dependabot configuration, adding new GitHub workflows for CI and code scanning, and enhancing the Go module management in the Makefile.

### GitHub Workflow and Configuration Updates:

* [`.github/copy-pr-bot.yaml`](diffhunk://#diff-2168c730c3c7ca28d888925505100acdc5141a2cc18864d104faa0f84227e7d2R1-R3): Enabled the copy-pr-bot for the repository.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R25-R36): Added configuration for dependabot to manage Docker dependencies in the `deployments/container` and `deployments/devel` directories.

### CI and Code Scanning Workflows:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R38): Added a new CI pipeline workflow that includes job definitions for code scanning and Go build processes.
* [`.github/workflows/code_scanning.yaml`](diffhunk://#diff-49813076e5a29258229d756b87cb2334b8613ac1f42059ac603c0bcec99e0107R1-R52): Added a new workflow for CodeQL analysis of Go code, triggered on pull requests and workflow calls.
* [`.github/workflows/golang.yaml`](diffhunk://#diff-90a28f4e7a85f2d9b70f33bb4408d471bfdfdd89db56816bc0ee810ba80a19fdR18-R74): Renamed from `.github/workflows/golang.yml` and updated to include steps for checking Go module versions and performing lint and build tasks.

### Go Module Management Enhancements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R39-R67): Added new targets for managing Go modules, including `mod-tidy`, `mod-vendor`, `mod-verify`, and `check-vendor`.

### Additional Changes:

* [`deployments/devel/Dockerfile`](diffhunk://#diff-b461f2ccf3c88988adebbfb505a37f9e745c0f08ae8c1eeef10264e746f7078bR1-R17): Added a Dockerfile to define the Go version used in the project, allowing dependabot to manage this version.
* [`hack/golang-version.sh`](diffhunk://#diff-e819e61bfbd329b38c3185d0df239a336cff840ac39d0944eb0d9725104f7da0R1-R22): Added a script to extract the Go version from the Dockerfile, used in the CI workflow.