### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # General approvers for the kubectl-nv codebase
-* @arangogutierrez @elezar @cdesiniotis
+* @arangogutierrez @cdesiniotis


### PR DESCRIPTION
Remove elezar to not be added as a reviwer.